### PR TITLE
Fix bug where an error is thrown when joining an empty room

### DIFF
--- a/client/src/rtc/meshConnection.js
+++ b/client/src/rtc/meshConnection.js
@@ -28,7 +28,9 @@ export default function (room) {
 
   // socket joined a room, start making connections
   socket.on('joined', sockets => {
-    selfId = sockets.pop().peerId;
+    if (sockets.length !== 0) {
+      selfId = sockets.pop().peerId;
+    }
     // if first one in room, done
     if (sockets.length === 0) {
       emitter.emit('connected');


### PR DESCRIPTION
There might be something else going on here.  Why is the sockets array empty on a re-join?  I think we should just destroy any room when it becomes empty
